### PR TITLE
pytest-monitor #3 - Compute user time and kernel time on a per test basis.

### DIFF
--- a/docs/sources/changelog.rst
+++ b/docs/sources/changelog.rst
@@ -2,5 +2,11 @@
 Changelog
 =========
 
+* :release:`next`
+* :feature:`PM #3` Compute user time and kernel time on a per test basis for clarity and ease of exploitation.
+
+* :release:`1.0.1 <2020-03-18>`
+* :bug:`PM #2` pytest-monitor hangs infinitely when a pytest outcome (skip, fail...) is issued.
+
 * :release:`1.0.0 <2020-02-20>`
 * :feature:`PM` Initial release

--- a/examples/pkg3/test_mod_cl.py
+++ b/examples/pkg3/test_mod_cl.py
@@ -1,6 +1,10 @@
+import time
+
 class TestClass:
     def setup_method(self, test_method):
         self.__value = test_method.__name__
+        time.sleep(1)
        
     def test_method1(self):
+        time.sleep(0.5)
         assert self.__value == "test_method1"

--- a/pytest_monitor/pytest_monitor.py
+++ b/pytest_monitor/pytest_monitor.py
@@ -173,14 +173,6 @@ def pytest_sessionstart(session):
     yield
 
 
-def scoper(scope, monitor_skip_flag, set_scope):
-    should_skip = monitor_skip_flag
-    if scope in set_scope and not should_skip:
-        global PYTEST_MONITOR_SESSION
-        return PYTEST_MONITOR_SESSION
-    return None
-
-
 @pytest.fixture(autouse=True, scope='module')
 def prf_module_tracer(request):
     t_a = time.time()

--- a/pytest_monitor/pytest_monitor.py
+++ b/pytest_monitor/pytest_monitor.py
@@ -169,6 +169,7 @@ def pytest_sessionstart(session):
     remote = None if session.config.option.mtr_none else session.config.option.remote
     PYTEST_MONITOR_SESSION = PyTestMonitorSession(db=db, remote=remote, component=component)
     PYTEST_MONITOR_SESSION.set_environment_info(ExecutionContext())
+    session.pytest_monitor = PYTEST_MONITOR_SESSION
     yield
 
 
@@ -183,29 +184,30 @@ def scoper(scope, monitor_skip_flag, set_scope):
 @pytest.fixture(autouse=True, scope='module')
 def prf_module_tracer(request):
     t_a = time.time()
+    ptimes_a = request.session.pytest_monitor.process.cpu_times()
     yield
-    wrt = scoper('module', False, request.config.option.mtr_scope)
-    if wrt is not None:
-        t_z = time.time()
-        process = psutil.Process(os.getpid())
-        rss = process.memory_info().rss / 1024 ** 2
-        ptimes = process.cpu_times()
-        component = getattr(request.module, 'pytest_monitor_component', '')
-        wrt.add_test_info(request.module.__name__, 'module', component,
-                          t_a, t_z - t_a, ptimes.user, ptimes.system,
-                          rss)
+    ptimes_b = request.session.pytest_monitor.process.cpu_times()
+    t_z = time.time()
+    rss = request.session.pytest_monitor.process.memory_info().rss / 1024 ** 2
+    component = getattr(request.module, 'pytest_monitor_component', '')
+    request.session.pytest_monitor.add_test_info(request.module.__name__, 'module', request.config.option.mtr_scope,
+                                                 component, t_a, t_z - t_a,
+                                                 ptimes_b.user - ptimes_a.user,
+                                                 ptimes_b.system - ptimes_a.system,
+                                                 rss)
 
 
 @pytest.fixture(autouse=True)
 def prf_tracer(request):
+    ptimes_a = request.session.pytest_monitor.process.cpu_times()
     yield
-    wrt = scoper('function', request.node.monitor_skip_test, request.config.option.mtr_scope)
-    if wrt is not None:
-        process = psutil.Process(os.getpid())
-        ptimes = process.cpu_times()
-        if request.node.monitor_results:
-            full_item_name = f'{request.module.__name__}/{request.node.name}'
-            wrt.add_test_info(full_item_name, 'function', request.node.monitor_component,
-                              request.node.test_effective_start_time,
-                              request.node.test_run_duration,
-                              ptimes.user, ptimes.system, request.node.mem_usage)
+    ptimes_b = request.session.pytest_monitor.process.cpu_times()
+    if not request.node.monitor_skip_test and request.node.monitor_results:
+        full_item_name = f'{request.module.__name__}/{request.node.name}'
+        request.session.pytest_monitor.add_test_info(full_item_name, 'function', request.config.option.mtr_scope,
+                                                     request.node.monitor_component,
+                                                     request.node.test_effective_start_time,
+                                                     request.node.test_run_duration,
+                                                     ptimes_b.user - ptimes_a.user,
+                                                     ptimes_b.system - ptimes_a.system,
+                                                     request.node.mem_usage)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -214,5 +214,3 @@ def test_monitor_skip_test_if(testdir):
     cursor = db.cursor()
     cursor.execute('SELECT ITEM FROM TEST_METRICS;')
     assert 2 == len(cursor.fetchall())  # current test + test_monitored
-
-


### PR DESCRIPTION
# Description
We now compute both user and kernel time for each tests regardless of the time taken by previous tests. 
The overhead remains minimal as the `PyTestMonitorSession` instance now holds an instance of `psutil.Process` object and is now injected at startup in the `request.session` object. The code gains in readability and all measures are taken in a consistent way (the test is the unit)

Fixes #3 

# Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

If an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (not just the [CI](https://link.to.ci))
- [x] I have provided a link to the issue this PR adresses in the Description section above
- [x] I have updated the [changelog](https://github.com/jsd-spif/pymonitor/blob/master/docs/sources/changelog.rst)
- [x] I have labeled my PR using appropriate tags (in particular using status labels

Do not forget to @ the people that needs to do the review

Thanks for contributing! :pray:
