### PR TITLE
Fix/pm #9

### DIFF
--- a/docs/sources/changelog.rst
+++ b/docs/sources/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :release:`1.1.1 <2020-03-31>`
+* :bug:`9` Fix remote server interface for sending measures.
+
 * :release:`1.1.0 <2020-03-30>`
 * :feature:`5` Extend item information and separate item from its variants.
 * :feature:`3` Compute user time and kernel time on a per test basis for clarity and ease of exploitation.


### PR DESCRIPTION
#Description

Fix the use of --remote option. The remote server interface was using the data model of version 1.0.* which breaks the ability to send results on a remote server.

Fixes #9 

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

If an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (not just the [CI](https://link.to.ci))
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have provided a link to the issue this PR adresses in the Description section above (If there is none yet,
[create one](https://github.com/CFMTech/pytest-monitor/issues) !)
- [x] I have updated the [changelog](https://github.com/CFMTech/pytest-monitor/blob/master/docs/sources/changelog.rst)
- [x] I have labeled my PR using appropriate tags (in particular using status labels like [`Status: Code Review Needed`](https://github.com/jsd-spif/pymonitor/labels/Status%3A%20Code%20Review%20Needed), [`Business: Test Needed`](https://github.com/CFMTech/pytest-monitor/labels/Business%3A%20Test%20Needed) or [`Status: In Progress`](https://github.com/CFMTech/pytest-monitor/labels/Status%3A%20In%20Progress) if you are still working on the PR)


Thanks for contributing! :pray:
