### PR TITLE
#31 - Changing option for sending results to remote server in order t…

### DIFF
--- a/docs/sources/changelog.rst
+++ b/docs/sources/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :release:`1.5.1 <2021-02-05>`
+* :bug:`#31` Rename option --remote as it seems to conflict with some plugins.  
+
 * :release:`1.5.0 <2020-11-20>`
 * :feature:`25` Automatically gather CI build information (supported CI are Drone CI, Gitlab CI, Jenkins CI, Travis CI, Circle CI)
 * :bug:`#23 major` psutil min requirement is now 5.1.0

--- a/docs/sources/exploitation.rst
+++ b/docs/sources/exploitation.rst
@@ -24,7 +24,7 @@ your Metrics and Execution Context (see below):
 
 .. code-block:: shell
 
-    pytest --remote server:port
+    pytest --remote-server server:port
 
 Execution Context, Metrics and Session
 --------------------------------------

--- a/docs/sources/remote.rst
+++ b/docs/sources/remote.rst
@@ -7,7 +7,7 @@ To do so, instruct pytest with the remote server address to use:
 
 .. code-block:: shell
 
-   bash $> pytest --remote myremote.server.net:port 
+   bash $> pytest --remote-server myremote.server.net:port 
 
 This way, *pytest-monitor* will automatically send and query the remote server as soon as it gets
 a need.  Note that *pytest-monitor* will revert to a normal behaviour if:

--- a/pytest_monitor/pytest_monitor.py
+++ b/pytest_monitor/pytest_monitor.py
@@ -31,7 +31,7 @@ def pytest_addoption(parser):
                     help='Set this option to distinguish parametrized tests given their values.'
                          ' This requires the parameters to be stringifiable.')
     group.addoption('--no-monitor', action='store_true', dest='mtr_none', help='Disable all traces')
-    group.addoption('--remote', action='store', dest='mtr_remote',
+    group.addoption('--remote-server', action='store', dest='mtr_remote',
                     help='Remote server to send the results to. Format is <ADRESS>:<PORT>')
     group.addoption('--db', action='store', dest='mtr_db_out', default='.pymon',
                     help='Use the given sqlite database for storing results.')


### PR DESCRIPTION
# Description

Rename option for sending results to remote server.

Fixes #31 

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

If an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (not just the [CI](https://link.to.ci))
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have provided a link to the issue this PR adresses in the Description section above (If there is none yet,
[create one](https://github.com/CFMTech/pytest-monitor/issues) !)
- [x] I have updated the [changelog](https://github.com/CFMTech/pytest-monitor/blob/master/docs/sources/changelog.rst)
- [x] I have labeled my PR using appropriate tags (in particular using status labels like [`Status: Code Review Needed`](https://github.com/jsd-spif/pymonitor/labels/Status%3A%20Code%20Review%20Needed), [`Business: Test Needed`](https://github.com/jsd-spif/pymonitor/labels/Business%3A%20Test%20Needed) or [`Status: In Progress`](https://github.com/jsd-spif/pymonitor/labels/Status%3A%20In%20Progress) if you are still working on the PR)

Do not forget to @ the people that needs to do the review

Thanks for contributing! :pray:
