### PR TITLE
#43 - Session tags are now sent to the remote server as JSON

### DIFF
--- a/pytest_monitor/session.py
+++ b/pytest_monitor/session.py
@@ -90,7 +90,7 @@ class PyTestMonitorSession(object):
                               json=dict(session_h=self.__session,
                                         run_date=run_date,
                                         scm_ref=scm,
-                                        description=description))
+                                        description=json.loads(description)))
             if r.status_code != HTTPStatus.CREATED:
                 self.__remote = ''
                 msg = "Cannot insert session in remote monitor server ({})! Deactivating...')".format(r.status_code)


### PR DESCRIPTION
**Describe the bug**
When running pytest-monitor with option --remote-server, I am unable to send measures to the remote server. I got the warning **Cannot insert session to remote monitor server (BAD REQUEST)**

**To Reproduce**
Using monitor-server-api as the remote server.

Fixes #43 