### PR TITLE
#40 - Force garbage collector to run between each tests

### DIFF
--- a/docs/sources/changelog.rst
+++ b/docs/sources/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* :release:`1.6.1 <2021-08-23>`
+* :bug:`#43` Fixes a bug that prevent sending session tags correctly.
+* :bug:`#40` Force garbage collector to run between tests (better result accuracy)
+
 * :release:`1.6.0 <2021-04-16>`
 * :feature:`#0` Support for python 3.5
 * :feature:`#35` Better support for Doctest item.

--- a/docs/sources/configuration.rst
+++ b/docs/sources/configuration.rst
@@ -165,3 +165,14 @@ The following table explains how both fields are mapped:
 Note that none of these two fields will be added if:
  * the CI context is incomplete
  * the CI context cannot be computed.
+
+Parameters affecting measures
+-----------------------------
+By default, pytest-monitor runs the garbage collector prior to execute the test function.
+This leads to finer memory measurements. In the case where you want to disable this call to the
+garbage collector, you just have to set the option `--no-gc` on the command line.
+
+.. code-block:: shell
+
+    bash $> pytest --no-gc
+

--- a/pytest_monitor/__init__.py
+++ b/pytest_monitor/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 __author__ = "Jean-Sebastien Dieu"

--- a/pytest_monitor/pytest_monitor.py
+++ b/pytest_monitor/pytest_monitor.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import gc
 import memory_profiler
 import pytest
 import time
@@ -44,6 +45,8 @@ def pytest_addoption(parser):
     group.addoption('--component-prefix', action='store', dest='mtr_component_prefix',
                     help='Prefix each found components with the given value (applies to all tests'
                          ' run in this session).')
+    group.addoption('--no-gc', action="store_true", dest="mtr_no_gc", 
+                    help='Disable garbage collection between tests (may leads to non reliable measures)')
     group.addoption('--description', action='store', default='', dest='mtr_description',
                     help='Use this option to provide a small summary about this run.')
     group.addoption('--tag', action='append', dest='mtr_tags', default=[],
@@ -154,6 +157,8 @@ def pytest_pyfunc_call(pyfuncitem):
     if not PYTEST_MONITORING_ENABLED:
         wrapped_function()
     else:
+        if pyfuncitem.session.config.option.mtr_no_gc:
+            gc.collect()
         prof()
     return True
 


### PR DESCRIPTION
# Description

Force garbage collector to run between tests. The call is done prior to run the test function body itself.
An option has been added to disable it so that the previous behavior can be kept if necessary.

Fixes #40 

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have provided a link to the issue this PR adresses in the Description section above
- [x] I have updated the [changelog](https://github.com/CFMTech/pytest-monitor/blob/master/docs/sources/changelog.rst)
- [x] I have labeled my PR using appropriate tags

Thanks for contributing! :pray:
