### PR TITLE
Wrong command for disabling monitoring

### DIFF
--- a/docs/sources/configuration.rst
+++ b/docs/sources/configuration.rst
@@ -76,7 +76,7 @@ which will lead to the following entries:
 Disable monitoring
 ------------------
 
-If you need for some reason to disable the monitoring, pass the *\-\-no-trace* option.
+If you need for some reason to disable the monitoring, pass the *\-\-no-monitor* option.
 
 
 Describing a run


### PR DESCRIPTION
The addopt command in documentation wasn't same with one in the source code. So I suggest to fix that


- [ ] This change requires a documentation update

# Checklist:

- [ ] ~My code follows the style guidelines of this project~
- [ ] ~I have performed a self-review of my own code~
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes (not just the [CI](https://link.to.ci))
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] ~I have provided a link to the issue this PR adresses in the Description section above (If there is none yet,
[create one](https://github.com/CFMTech/pytest-monitor/issues) !)~
- [ ] I have updated the [changelog](https://github.com/CFMTech/pytest-monitor/blob/master/docs/sources/changelog.rst)
- [ ] I have labeled my PR using appropriate tags (in particular using status labels like [`Status: Code Review Needed`](https://github.com/jsd-spif/pymonitor/labels/Status%3A%20Code%20Review%20Needed), [`Business: Test Needed`](https://github.com/jsd-spif/pymonitor/labels/Business%3A%20Test%20Needed) or [`Status: In Progress`](https://github.com/jsd-spif/pymonitor/labels/Status%3A%20In%20Progress) if you are still working on the PR)

Do not forget to @ the people that needs to do the review

Thanks for contributing! :pray:
