### PR TITLE
Avoid AttributeError for monitor_results on teardown

### DIFF
--- a/pytest_monitor/pytest_monitor.py
+++ b/pytest_monitor/pytest_monitor.py
@@ -227,7 +227,7 @@ def prf_tracer(request):
         ptimes_a = request.session.pytest_monitor.process.cpu_times()
         yield
         ptimes_b = request.session.pytest_monitor.process.cpu_times()
-        if not request.node.monitor_skip_test and request.node.monitor_results:
+        if not request.node.monitor_skip_test and getattr(request.node, "monitor_results", False):
             item_name = request.node.originalname or request.node.name
             item_loc = getattr(request.node, PYTEST_MONITOR_ITEM_LOC_MEMBER)[0]
             request.session.pytest_monitor.add_test_info(item_name, request.module.__name__,


### PR DESCRIPTION
# Description

This is a naive resolution to https://github.com/CFMTech/pytest-monitor/issues/50.  It may not really make sense but it does seem to avoid the exception by using `getattr(request.node, "monitor_results", False)` to both avoid the attribute error and to avoid running the rest of the code in this unexpected scenario.

This is primarily being shared as a reference point.  If you see other things that should be done feel free let me know, replace this with another PR, or just push changes here.

Fixes #50

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

If an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (not just the [CI](https://link.to.ci))
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have provided a link to the issue this PR adresses in the Description section above (If there is none yet,
[create one](https://github.com/CFMTech/pytest-monitor/issues) !)
- [ ] I have updated the [changelog](https://github.com/CFMTech/pytest-monitor/blob/master/docs/sources/changelog.rst)
- [ ] I have labeled my PR using appropriate tags (in particular using status labels like [`Status: Code Review Needed`](https://github.com/jsd-spif/pymonitor/labels/Status%3A%20Code%20Review%20Needed), [`Business: Test Needed`](https://github.com/jsd-spif/pymonitor/labels/Business%3A%20Test%20Needed) or [`Status: In Progress`](https://github.com/jsd-spif/pymonitor/labels/Status%3A%20In%20Progress) if you are still working on the PR)
