### PR TITLE
enh/#64: Stop support for Python<=3.7 and pytest<=5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,7 @@ If you encounter any problem, please `file an issue`_ along with a detailed desc
 Author
 ------
 
-The main author of `pytest-monitor` is Jean-Sébastien Dieu, who can be reached at jean-sebastien.dieu@cfm.fr.
+The main author of `pytest-monitor` is Jean-Sébastien Dieu, who can be reached at jdieu@salsify.fr.
 
 ----
 

--- a/docs/sources/changelog.rst
+++ b/docs/sources/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* :release:`1.6.6 <2023-05-06>`
+* :bug:`#64` Prepare version 1.7.0 of pytest-monitor. Last version to support Python <= 3.7 and all pytest <= 5.*
+* :bug:`#` Improve and fix some CI issues, notably one that may cause python to not be the requested one but a more recent one.
+
 * :release:`1.6.5 <2022-10-16>`
 * :bug:`#60` Make sure that when psutil cannot fetch cpu frequency, the fallback mechanism is used.
 


### PR DESCRIPTION
Last version to support old python version (up to 3.7 included) and old version of pytest (includes all declination of version 5).

