### PR TITLE
fix(ci): Pin attrs to a compatible python 3.6 version

### DIFF
--- a/docs/sources/changelog.rst
+++ b/docs/sources/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 
 * :release:`1.6.6 <2023-05-06>`
 * :bug:`#64` Prepare version 1.7.0 of pytest-monitor. Last version to support Python <= 3.7 and all pytest <= 5.*
-* :bug:`Reworked CI workflow` Improve and fix some CI issues, notably one that may cause python to not be the requested one but a more recent one.
+* :bug:`#0` Improve and fix some CI issues, notably one that may cause python to not be the requested one but a more recent one.
 
 * :release:`1.6.5 <2022-10-16>`
 * :bug:`#60` Make sure that when psutil cannot fetch cpu frequency, the fallback mechanism is used.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ psutil>=5.1.0
 memory_profiler>=0.58
 pytest
 requests
+attrs<=22.2.0


### PR DESCRIPTION
Pytest 6.1 and older requires attrs, which recently breaks python 3.6 compatibility. The point here is to pin attrs to allow pytest-monitor to publish a final package compatible for python 3.6.